### PR TITLE
【feature】ユーザー一覧ページのデザイン実装 close #10

### DIFF
--- a/frontend/src/views/users/index.jsx
+++ b/frontend/src/views/users/index.jsx
@@ -1,5 +1,174 @@
+import { Link, useNavigate } from "react-router-dom"
+import { RoutePath } from "config/route_path.js";
+import { useEffect, useState } from "react";
+
+const usersData = [...Array(20).keys()].map((val) => {
+  return {
+    id: val,
+    name: "とぴ",
+    nickname: `とぴ${val}`,
+    pastname: "とっぴ",
+    term: "52期A",
+    term_id: 52,
+    github_account: "topi0247",
+    prefecture: "長野県",
+    prefecture_id: 20,
+    avatar: "https://pbs.twimg.com/profile_images/1750171124573540352/19Gfg3oh_400x400.jpg",
+    user_tags: [
+      {
+        id: 1,
+        name: "Ruby",
+        position: "1"
+      },
+      {
+        id: 2,
+        name: "Ruby on Rails",
+        position: "2"
+      },
+      {
+        id: 3,
+        name: "JavaScript",
+        position: "3"
+      }
+    ],
+    user_social_service: [
+      {
+        name: "twitter",
+        account_name: "topi_log"
+      },
+      {
+        name: "times",
+        account_name: "52a_nishina_kanae"
+      },
+    ]
+  };
+});
+
 export const UsersIndex = () => {
+
+  const [searchWord, setSearchWord] = useState("");
+  const [searchTerm, setSearchTerm] = useState("");
+  const [users, setUsers] = useState(usersData);
+  const [isSearch, setIsSearch] = useState(false);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    // リロードではURLを取得できないため、window.location.hrefで取得
+    // TODO : リロードで検索初期化するのかどうかで実装変更
+    const url = window.location.href;
+    const query = url.split("?")[1];
+    let queryWord = query ? decodeURIComponent(query.split("&")[0].split("=")[1]) : "";
+    let queryTerm = query ? decodeURIComponent(query.split("&")[1].split("=")[1]) : "";
+
+    // TODO : 検索でのユーザー取得処理
+    console.log(queryWord, queryTerm);
+
+    setSearchWord(queryWord);
+    setSearchTerm(queryTerm);
+    setUsers(usersData); // 検索で取得したユーザーデータをセット
+    setIsSearch(false);
+  }, []);
+
+  useEffect(() => {
+    if (!isSearch) return;
+    const queryWord = (searchWord && searchWord !== undefined) ? searchWord.split(",") : "";
+    const queryTerm = (searchTerm && searchTerm !== undefined) ? searchTerm : "";
+
+    // TODO : 検索でのユーザー取得処理
+    console.log(queryWord, queryTerm);
+
+    setUsers(usersData); // 検索で取得したユーザーデータをセット
+    setIsSearch(false);
+  }, [isSearch]);
+
+  const handleOnSubmit = (e) => {
+    e.preventDefault();
+    if (searchWord === "" && searchTerm === "") return;
+
+    let query = "?";
+    if (searchWord !== "") {
+      // カンマ、読点、半角スペース、全角スペースで分割
+      // filter(Boolean)は空文字削除用
+      const splitWord = searchWord.trim().split(/[,、\s\u3000]+/g).filter(Boolean);
+      query += `word=${splitWord.join(",")}`;
+    }
+    if (searchTerm !== "") {
+      query += query === "?" ? `term=${searchTerm}` : `&term=${searchTerm}`;
+    }
+    navigate(RoutePath.Users.path + query);
+    setIsSearch(true);
+  }
+
+  const handleSearchWord = (e) => {
+    setSearchWord(e.target.value);
+  }
+
+  const handleSearchTerm = (e) => {
+    setSearchTerm(e.target.value);
+  }
+
+
   return (
-    <div>UsersIndex</div>
+    <>
+      <section className="flex flex-col justify-center items-end m-7 mr-20">
+        <form className="flex gap-2" onSubmit={handleOnSubmit}>
+          <input type="text" onChange={handleSearchWord} placeholder="Rails React" className="input rounded  border-orange-300 focus:outline-orange-500" id="search_word" value={searchWord} />
+          {/* TODO : ここをどう実装するか。そもそも必要かは検討したほうがよさげ */}
+          <select className="select select-bordered rounded border-orange-200 focus:outline-orange-500" id="search_term" value={searchTerm} onChange={handleSearchTerm}>
+            <option value="">入学期</option>
+            <option value="50a">50期A</option>
+            <option value="50b">50期B</option>
+            <option value="51a">51期A</option>
+            <option value="51b">51期B</option>
+            <option value="52a">52期A</option>
+            <option value="pro1">pro1</option>
+            <option value="52b">52期B</option>
+          </select>
+          <button className="btn bg-runteq-primary text-white px-6 tracking-wider">検索</button>
+          <Link to={RoutePath.Users.path} className="btn bg-runteq-primary text-white px-6 tracking-wider">リセット</Link>
+        </form>
+      </section>
+      <section className="flex flex-wrap">
+        {users.map((user) => (
+          <div key={user.id} className="card w-96 border border-black m-4 shadow-xl overflow-hidden hover:shadow-2xl group rounded-xl p-5 transition-all duration-200 transform">
+            <Link to={`${RoutePath.Users.path}?term=${user.term_id}`} className="text-xl px-2 ml-auto hover:opacity-50 transition-all">{user.term}</Link>
+            <div className="flex px-2 items-center gap-4">
+              <img src={user.avatar}
+                class="w-32 group-hover:w-36 group-hover:h-36 h-32 object-center object-cover rounded-full transition-all duration-200 delay-200 transform"
+                alt="Avatar"
+              />
+              <div class="p-4 transition-all transform duration-200">
+                <h1 class="card-title font-bold">
+                  <Link to={RoutePath.UsersShow.path(user.id)} className="hover:opacity-50 transition-all">{user.nickname}</Link>
+                </h1>
+                <p className="text-sm">（旧：{user.pastname}）</p>
+                <Link to={`${RoutePath.Users.path}?prefecture=${user.prefecture_id}`} className="inline-flex item-center text-sm py-4 hover:opacity-50 transition-all">
+                  <svg className="h-5 w-5"
+                    xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+                    <path
+                      d="M5.64 16.36a9 9 0 1 1 12.72 0l-5.65 5.66a1 1 0 0 1-1.42 0l-5.65-5.66zm11.31-1.41a7 7 0 1 0-9.9 0L12 19.9l4.95-4.95zM12 14a4 4 0 1 1 0-8 4 4 0 0 1 0 8zm0-2a2 2 0 1 0 0-4 2 2 0 0 0 0 4z" />
+                  </svg>
+                      {user.prefecture}
+                </Link>
+              </div>
+            </div>
+            <ul className="flex gap-3 justify-end items-center px-2">
+              <li><Link to='#' className="hover:opacity-50 transition-all">X<i className="fa-brands fa-x-twitter fa-xl" /></Link></li>
+              <li><Link to='#'className="hover:opacity-50 transition-all">MattermostLogo</Link></li>
+            </ul>
+            <div className="px-2 pt-2 ml-auto group-hover:opacity-100 opacity-0 transform transition-all delay-300 duration-200">
+              <Link to={RoutePath.UsersShow.path(user.id)}>詳細 →</Link>
+            </div>            
+            {user.user_tags?.length > 0 &&
+              <div className="p-2 m-4 border-t border-black">
+                {user.user_tags.map((tag, index) => (
+                  <Link to={`${RoutePath.Users.path}?tag=${tag.id}`} key={index} className="badge badge-outline hover:opacity-50 transition-all mr-2">{tag.name}</Link>
+                ))}
+              </div>
+            }
+          </div>
+        ))}
+      </section>
+    </>
   )
 }


### PR DESCRIPTION
# 概要
ユーザー一覧ページのデザイン実装

## 実装内容

https://github.com/rayto298/runtecker/assets/148407473/d09047de-29a9-406f-8f8b-030536534023



## 実装項目
- [x] ニックネームと「詳細→」からユーザー詳細に遷移
- [x] term、居住地、タグからもそれぞれのページに遷移   

## 補足
カードをhoverすることで「詳細→」の文字列が表示されるようにしています。
ユーザー一覧ではユーザーが一番確認しそうなXとマタモのみ表示しました。
Xとマタモは遷移ページの設定は詳細ページとの関連もあるため実装してません。
検索バーはとぴさんが実装していただいたまま移行しました。

## 備考
他なにか書いておきたいことがあればここに記載