### PR TITLE
GitHub Actionsによる自動DBmigrateの設定を追加 close 8

### DIFF
--- a/.github/workflows/heroku-backend.yml
+++ b/.github/workflows/heroku-backend.yml
@@ -20,3 +20,7 @@ jobs:
           dockerfile_name: Dockerfile
           docker_options: "--no-cache"
           process_type: web
+      - name: DB migrate on Heroku
+        run: heroku run rails db:migrate -a ${{ secrets.HEROKU_BACKEND_APP_NAME }}
+        env:
+          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}


### PR DESCRIPTION
# 概要
GitHub Actionsによって自動的にHeroku上でrails db:migareteが実行されるように設定しました。

## 挙動
runteckerを複製したアプリ（runtecker-test）を用意し、今回のheroku-backend.ymlの修正内容と同じ内容を適用して動作確認した際の画面キャプチャを貼ります。

・デプロイ処理の後に「rails db:migarate」が実行され、成功していることを確認
<img width="1439" alt="image" src="https://github.com/rayto298/runtecker/assets/128275327/dd8a91e6-915a-43c6-9f11-32bf0afc2111">

・db:migrateで作られたテーブル（Board）に、レコードが作成できることを確認
<img width="885" alt="image" src="https://github.com/rayto298/runtecker/assets/128275327/28522932-a41b-4950-8a57-6396d7dac6e5">

・Heorku上で、作成したレコードが表示されることを確認
<img width="585" alt="image" src="https://github.com/rayto298/runtecker/assets/128275327/ab2533d7-167a-4ef7-ab52-31522ecfd3fa">


## 実装内容
backendディレクトリ配下のファイルが更新されてGitHubのmainブランチにマージされた際に、GitHub Actionsによって自動的にHeroku上でrails db:migareteが実行されるように設定しました。

## 実装項目
.github/workflows/heroku-backend.yml を修正しているのみです。

## 補足
本番環境でのみ動作する設定のため、実際のrunteckerの環境では動作確認できていません。
代わりに、runtecker-testという同構成の環境（runteckerを複製したソースコード、新たなGitHubリポジトリ、新たなHerokuアプリ）を用意して動作確認を実施し、その結果を「挙動」のところに貼っています。

## 備考
マイグレーションファイル（db/migrate 配下）が追加、更新された時のみ rails db:migarate が走るようにする設定が良いかと考えましたが、そうすると新たにymlを作る必要がありそうでした。ファイル構成はシンプルにしたかったので、backend配下に更新が走った場合に必ずrails db:migrateも実行されるような作りになっています。
マイグレーションファイルに追加、更新がない場合にrails db:migarateが動いても、以下のように正常終了し特に動作に悪影響がないことは確認済みです。
<img width="1440" alt="image" src="https://github.com/rayto298/runtecker/assets/128275327/b0f58007-9b2a-4e4a-b1ee-3a42e8e4e3d2">
