### PR TITLE
【feature】Github認証機能#30 #31 ユーザー作成に必要な為

### DIFF
--- a/backend/db/seeds.rb
+++ b/backend/db/seeds.rb
@@ -16,7 +16,7 @@ prefectures = [
   "鳥取県", "島根県", "岡山県", "広島県", "山口県", 
   "徳島県", "香川県", "愛媛県", "高知県", "福岡県", 
   "佐賀県", "長崎県", "熊本県", "大分県", "宮崎県", 
-  "鹿児島県", "沖縄県"
+  "鹿児島県", "沖縄県", "その他", "-"
 ] 
 prefectures.each do |pref_name|
   Prefecture.find_or_create_by(name: pref_name)


### PR DESCRIPTION
# 概要
ユーザーアカウントを作成するために必要な為、seedにtermとprefectureを追加しました。

## 挙動
テストユーザー作成

![image](https://github.com/rayto298/runtecker/assets/143789647/42a46940-2993-49ac-bd16-7b3aa9b1b830)


## 実装内容

https://github.com/rayto298/runtecker/assets/143789647/48377459-dd1e-4fb8-95b6-4ac9825f227a


https://github.com/rayto298/runtecker/assets/143789647/fa435ac2-97e2-438d-abfc-4e45c840ee38


## 実装項目
- [x] Term
- [x] Prefecture