### PR TITLE
ユーザプロフィール編集画面を移行 close #11

### DIFF
--- a/frontend/src/views/users/components/_edit.jsx
+++ b/frontend/src/views/users/components/_edit.jsx
@@ -1,5 +1,108 @@
-export const _UsersEdit = () => {
+import { RoutePath } from "config/route_path";
+import { Link } from "react-router-dom";
+import { _UsersEditService } from "./_edit_service";
+
+export const _UsersEdit = ({ user, toggleEdit }) => {
+  // プレビュー用
+  const handleClickImagePreview = () => {
+    let inputElement = document.createElement("input");
+    inputElement.type = "file";
+    inputElement.accept = "image/*";
+    inputElement.click();
+    inputElement.onchange = (e) => {
+      const file = e.target.files[0];
+      if (!file) return;
+      å;
+      const reader = new FileReader();
+      reader.onload = (e) => {
+        // プレビュー用にデータを取得・表示
+        setUser({ ...user, image: e.target.result });
+      };
+      reader.readAsDataURL(file);
+    };
+  };
+
+  // サービス名をセット
+  const serviceNames = ["X", "MatterMost", "Qiita", "note", "Zenn"];
+
+  // アカウント名をセット
+  const accountNames = ["rayto-x", "", "rayto-qiita", "", "rayto-zenn"];
+
   return (
-    <div>_edit</div>
-  )
-}
+    <>
+      <div className="w-full text-end">
+        <button onClick={toggleEdit} className="btn text-xs">
+          戻る
+        </button>
+      </div>
+      <div className="flex justify-between w-full">
+        <div className="flex w-1/2 flex-col items-center justify-center">
+          <input
+            type="text"
+            placeholder={user.nickname}
+            className="input text-center w-4/5 max-w-xs rounded-md text-2xl"
+          />
+          <p className="text-sm">（旧：{user.pastname}）</p>
+        </div>
+        <div className="w-1/2 flex justify-center items-center text-2xl gap-2">
+          <p>{user.term}</p>
+          <select className="ms-1 select text-center w-2/5 max-w-xs rounded-md text-lg">
+            <option>長野県</option>
+            <option>東京都</option>
+            <option>大阪府</option>
+            <option>愛知県</option>
+            <option>北海道</option>
+            <option>沖縄県</option>
+          </select>
+        </div>
+      </div>
+      <div className="py-4 w-full">
+        <figure className="w-full">
+          <div className="text-center flex justify-center items-center">
+            <button
+              className="bg-black bg-opacity-100 text-center hover:bg-opacity-100 transition-all w-auto h-auto relative flex justify-center items-center"
+              onClick={handleClickImagePreview}
+            >
+              <img
+                src={user.avatar}
+                className="m-auto h-[300px] opacity-60 hover:opacity-40 transition-all"
+              />
+            </button>
+          </div>
+        </figure>
+      </div>
+      <div>
+        {serviceNames.map((serviceName, index) => (
+          <_UsersEditService
+            key={index}
+            serviceName={serviceName}
+            accountName={accountNames[index]}
+          />
+        ))}
+      </div>
+      {user.user_tags?.length > 0 && (
+        <div className="text-center my-2">
+          {user.user_tags.map((tag, index) => (
+            <Link
+              to={`${RoutePath.Users.path}?tag=${tag.id}`}
+              key={index}
+              className="bg-gray-200 text-xs px-2 py-1 rounded-full m-1"
+            >
+              {tag.name}
+            </Link>
+          ))}
+        </div>
+      )}
+      <textarea
+        className="textarea w-full rounded-md"
+        rows={10}
+        defaultValue={user.profile}
+      />
+      <div className="w-full text-center">
+        <button onClick={toggleEdit} className="btn btn-primary text-xs mt-3">
+          変更内容を保存
+        </button>
+      </div>
+    </>
+  );
+};

--- a/frontend/src/views/users/components/_edit_service.js
+++ b/frontend/src/views/users/components/_edit_service.js
@@ -1,0 +1,28 @@
+export const _UsersEditService = ({ serviceName, accountName }) => {
+  return (
+    <div className="mt-1 flex rounded-md shadow-sm w-1/2 m-auto">
+      <label
+        htmlFor="mattermost"
+        className="block text-sm font-medium flex m-auto"
+      >
+        【ロゴ】
+      </label>
+      <span className="w-1/4 inline-flex h-10 items-center px-3 rounded-l-md border border-r-0 border-gray-300 bg-gray-50 text-gray-500">
+        {serviceName === "MatterMost" ? "times_" : serviceName}
+      </span>
+      <input
+        id="userID"
+        name="userID"
+        placeholder={
+          serviceName === "MatterMost"
+            ? "times_以降を入力"
+            : "アカウント名を入力"
+        }
+        type="text"
+        required
+        defaultValue={accountName}
+        className="flex-1 form-input pl-3 block w-full rounded-none rounded-r-md transition duration-150 ease-in-out border"
+      />
+    </div>
+  );
+};


### PR DESCRIPTION
# 概要
ユーザプロフィール編集画面を以前仮作成してもらっていた[こちら](https://github.com/1019fuku/Test_Project_X_0223_Test/blob/main/src/views/users/EditProfile.jsx)から移行しました

## 挙動
ユーザプロフィール画面の動作です。イベントは未実装なので動作イメージだけ掴んでいただければと思います。
![7d5149cad2657bf826bf03a2e6bc39cb](https://github.com/rayto298/runtecker/assets/128275327/6cb475eb-45cc-4197-b996-b61453fd2378)


## 実装内容
実際の画面構成です。
<img width="394" alt="image" src="https://github.com/rayto298/runtecker/assets/128275327/4a1d4f87-850b-4af6-9e0d-deb6590f36aa">

## 実装項目
- [x] 画像を差し替えたときのプレビュー表示
- [x] 名前の変更
- [x] 都道府県の変更
- [x] 各リンクの編集
- [x] 自己紹介の編集
- [x] イベントの追加は無し

## 補足
プロフィール欄のマークダウンは未実装です。

## 備考
機能実装の段階で以下を入れる想定ですが、他に何か入れた方が良いものなど気づいた方がいたらご指摘ください！

<MVPまでに実装予定>
・ロゴ
・タグ
・バックエンドとの連携
・更新した状態で「戻る」や「リロード」を押した時に、「変更内容を破棄してよろしいですか？」のメッセージを出す
・プロフィールのマークダウン化（MVPまでにできたら）