### PR TITLE
【認証】RUNTEQ生以外がログインしようとした時は専用ページにリダイレクトする

### DIFF
--- a/backend/app/controllers/sessions_controller.rb
+++ b/backend/app/controllers/sessions_controller.rb
@@ -15,7 +15,8 @@ class SessionsController < ApplicationController
     unless GithubOrgMemberCheckService.new(github_username: github_username).member?
       Rails.logger.info("RunteqのGithubメンバーでない")
       # 組織のメンバーでなければフロントのindexに遷移
-      redirect_to "http://localhost:8000"
+      redirect_to "http://localhost:8000/not_runtecker"
+      return
     end
 
     # GitHubのユーザーIDを使ってトークンを生成

--- a/frontend/src/config/route_path.js
+++ b/frontend/src/config/route_path.js
@@ -13,10 +13,10 @@ export const RoutePath = {
   },
   UsersNew: {
     path: "/users/new",
-    name: "新規登録"
+    name: "新規登録",
   },
   UsersShow: {
-    path: (id = ':id') => `/users/${id}`,
+    path: (id = ":id") => `/users/${id}`,
     name: "プロフィール",
   },
   Curriculums: {
@@ -28,7 +28,7 @@ export const RoutePath = {
     name: "就活対策",
   },
   JobMeasuresShow: {
-    path: (id = ':id') => `/job_measures/:${id}`,
+    path: (id = ":id") => `/job_measures/:${id}`,
     name: "就活対策詳細",
   },
   Events: {
@@ -36,7 +36,7 @@ export const RoutePath = {
     name: "イベント",
   },
   EventsShow: {
-    path: (id = ':id') => `/events/:${id}`,
+    path: (id = ":id") => `/events/:${id}`,
     name: "イベント詳細",
   },
   Recruits: {
@@ -44,11 +44,15 @@ export const RoutePath = {
     name: "求人",
   },
   RecruitsShow: {
-    path: (id = ':id') => `/recruits/:${id}`,
+    path: (id = ":id") => `/recruits/:${id}`,
     name: "求人詳細",
   },
   NotFound: {
     path: "*",
     name: "NotFound",
   },
-}
+  NotRuntecker: {
+    path: "/not_runtecker",
+    name: "Runteq案内",
+  },
+};

--- a/frontend/src/routes/public.jsx
+++ b/frontend/src/routes/public.jsx
@@ -1,21 +1,22 @@
-import { Suspense } from "react"
-import { MainLayout } from "views/layouts/main_layout"
-import { _Loading } from "views/layouts/components/_loading"
-import { Outlet } from "react-router-dom"
-import { RoutePath } from "config/route_path"
-import { CurriculumsIndex } from "views/curriculums"
-import { EventsIndex } from "views/events"
-import { EventsShow } from "views/events/show"
-import { JobMeasuresIndex } from "views/job_measures"
-import { JobMeasuresShow } from "views/job_measures/show"
-import { RecruitsIndex } from "views/recruits"
-import { RecruitsShow } from "views/recruits/show"
-import { UsersIndex } from "views/users"
-import { UsersNew } from "views/users/new"
-import { UsersShow } from "views/users/show"
-import { StaticPagesIndex } from "views/static_pages"
-import { StaticPagesNotfound } from "views/static_pages/not_found"
-import { UserSessionsNew } from "views/user_sessions/new"
+import { Suspense } from "react";
+import { MainLayout } from "views/layouts/main_layout";
+import { _Loading } from "views/layouts/components/_loading";
+import { Outlet } from "react-router-dom";
+import { RoutePath } from "config/route_path";
+import { CurriculumsIndex } from "views/curriculums";
+import { EventsIndex } from "views/events";
+import { EventsShow } from "views/events/show";
+import { JobMeasuresIndex } from "views/job_measures";
+import { JobMeasuresShow } from "views/job_measures/show";
+import { RecruitsIndex } from "views/recruits";
+import { RecruitsShow } from "views/recruits/show";
+import { UsersIndex } from "views/users";
+import { UsersNew } from "views/users/new";
+import { UsersShow } from "views/users/show";
+import { StaticPagesIndex } from "views/static_pages";
+import { StaticPagesNotfound } from "views/static_pages/not_found";
+import { UserSessionsNew } from "views/user_sessions/new";
+import { StaticPagesNotRuntecker } from "views/static_pages/not_runtecker";
 
 const App = () => {
   return (
@@ -23,8 +24,8 @@ const App = () => {
       <Suspense fallback={<_Loading />} />
       <Outlet />
     </MainLayout>
-  )
-}
+  );
+};
 
 //  TODO : ユーザー認証確定するまでルーティングを暫定的に設定しています。
 export const PUBLIC_ROUTES = [
@@ -45,6 +46,10 @@ export const PUBLIC_ROUTES = [
       { path: RoutePath.UsersNew.path, element: <UsersNew /> },
       { path: RoutePath.UsersShow.path(), element: <UsersShow /> },
       { path: RoutePath.NotFound.path, element: <StaticPagesNotfound /> },
-    ]
-  }
-]
+      {
+        path: RoutePath.NotRuntecker.path,
+        element: <StaticPagesNotRuntecker />,
+      },
+    ],
+  },
+];

--- a/frontend/src/views/static_pages/not_runtecker.jsx
+++ b/frontend/src/views/static_pages/not_runtecker.jsx
@@ -1,0 +1,31 @@
+export const StaticPagesNotRuntecker = () => {
+  return (
+    <>
+      <div class="container mx-auto p-4">
+        <h1 class="text-2xl font-bold mb-4">RUNTECKER</h1>
+        <p>
+          本アプリはRUNTEQメンバー*のみご利用いただけます。（*Gitub
+          RUNTEQ組織メンバー）
+        </p>
+        <p>お客様のアカウントを確認することができませんでした。</p>
+        <p>
+          お手数をおかけしますがGithubアカウントをご確認いただくか、RUNTEQへの入学をご検討ください。
+        </p>
+
+        <div class="bg-white shadow-md rounded p-4 mt-6">
+          <h2 class="text-xl font-bold mb-3">RUNTEQ</h2>
+          <h2 class="text-xl font-bold mb-3">
+            <a
+              href="https://runteq.jp/"
+              target="_blank"
+              class="text-runteq-primary"
+            >
+              公式WEBサイト
+            </a>
+          </h2>
+          <p>本アプリに関する問い合わせはお控えください。</p>
+        </div>
+      </div>
+    </>
+  );
+};


### PR DESCRIPTION
## 概要
RUNTEQのGithub 組織に所属しないものが認証ボタンを押した際には、not_runteckerという静的ページに遷移するようにしました。ユーザーテーブルの更新もせず、トークンの割り当ても行いません。

## 動画
私のGithub別アカウント（RUNTEQで使用していない）で認証を試みることで検証しています。

https://www.youtube.com/watch?v=dKXZFJPmujA


## 遷移先画面スクリーンショット
https://gyazo.com/afd9ac3e06329db8354a8135b9769606
