### PR TITLE
【feature】ユーザプロフィールの動的な編集

### DIFF
--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -11,13 +11,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[7.0].define(version: 2024_03_11_140126) do
-  create_table "members", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.string "github_username"
-    t.integer "github_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
   create_table "past_nicknames", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.string "nickname"

--- a/frontend/src/views/users/components/_edit.jsx
+++ b/frontend/src/views/users/components/_edit.jsx
@@ -1,9 +1,37 @@
 import { RoutePath } from "config/route_path";
 import { Link } from "react-router-dom";
 import { _UsersEditService } from "./_edit_service";
+import { useState } from "react";
 
 export const _UsersEdit = ({ user, setUser, toggleEdit }) => {
-  // プレビュー用
+  // 都道府県の仮データ
+  const prefectures = [
+    { id: 1, name: "北海道" },
+    { id: 2, name: "青森県" },
+    { id: 3, name: "岩手県" },
+    { id: 4, name: "宮城県" },
+    { id: 5, name: "長野県" },
+    { id: 6, name: "山形県" },
+    { id: 7, name: "福島県" },
+    { id: 8, name: "茨城県" },
+    { id: 9, name: "栃木県" },
+    { id: 10, name: "群馬県" },
+  ];
+
+  // ニックネーム
+  const [nickname, setNickname] = useState(user.nickname);
+  const handleNicknameChange = (e) => {
+    setNickname(e.target.value);
+  };
+
+  // 都道府県
+  const [prefecture, setPrefecture] = useState(user.prefecture);
+  const handlePrefectureChange = (e) => {
+    setPrefecture(e.target.value);
+  };
+
+  // アバター
+  const [avatar, setAvatar] = useState(user.avatar);
   const handleClickImagePreview = () => {
     let inputElement = document.createElement("input");
     inputElement.type = "file";
@@ -14,18 +42,18 @@ export const _UsersEdit = ({ user, setUser, toggleEdit }) => {
       if (!file) return;
       const reader = new FileReader();
       reader.onload = (e) => {
-        // プレビュー用にデータを取得・表示
-        setUser({ ...user, image: e.target.result });
+        // 読み込まれた画像データを状態にセット
+        setAvatar(e.target.result);
       };
       reader.readAsDataURL(file);
     };
   };
 
-  // サービス名をセット
-  const serviceNames = ["X", "MatterMost", "Qiita", "note", "Zenn"];
-
-  // アカウント名をセット
-  const accountNames = ["rayto-x", "", "rayto-qiita", "", "rayto-zenn"];
+  // 自己紹介
+  const [profile, setProfile] = useState(user.profile);
+  const handleProfileChange = (e) => {
+    setProfile(e.target.value);
+  };
 
   return (
     <>
@@ -34,27 +62,38 @@ export const _UsersEdit = ({ user, setUser, toggleEdit }) => {
           戻る
         </button>
       </div>
+
+      {/* ニックネーム */}
       <div className="flex justify-between w-full">
         <div className="flex w-1/2 flex-col items-center justify-center">
           <input
             type="text"
-            placeholder={user.nickname}
+            placeholder="ニックネーム"
+            value={nickname}
+            onChange={handleNicknameChange}
             className="input text-center w-4/5 max-w-xs rounded-md text-2xl"
           />
           <p className="text-sm">（旧：{user.pastname}）</p>
         </div>
+
+        {/* 都道府県 */}
         <div className="w-1/2 flex justify-center items-center text-2xl gap-2">
           <p>{user.term}</p>
-          <select className="ms-1 select text-center w-2/5 max-w-xs rounded-md text-lg">
-            <option>長野県</option>
-            <option>東京都</option>
-            <option>大阪府</option>
-            <option>愛知県</option>
-            <option>北海道</option>
-            <option>沖縄県</option>
+          <select
+            className="ms-1 select text-center w-2/5 max-w-xs rounded-md text-lg"
+            value={prefecture}
+            onChange={handlePrefectureChange}
+          >
+            {prefectures.map((prefecture) => (
+              <option key={prefecture.id} value={prefecture.name}>
+                {prefecture.name}
+              </option>
+            ))}
           </select>
         </div>
       </div>
+
+      {/* アバター */}
       <div className="py-4 w-full">
         <figure className="w-full">
           <div className="text-center flex justify-center items-center">
@@ -63,22 +102,27 @@ export const _UsersEdit = ({ user, setUser, toggleEdit }) => {
               onClick={handleClickImagePreview}
             >
               <img
-                src={user.avatar}
+                src={avatar}
                 className="m-auto h-[300px] opacity-60 hover:opacity-40 transition-all"
+                alt="プロフィール画像"
               />
             </button>
           </div>
         </figure>
       </div>
+
+      {/* サービスのリンク */}
       <div>
-        {serviceNames.map((serviceName, index) => (
+        {user.user_social_service.map((service, index) => (
           <_UsersEditService
             key={index}
-            serviceName={serviceName}
-            accountName={accountNames[index]}
+            serviceName={service.name}
+            accountName={service.account_name}
           />
         ))}
       </div>
+
+      {/* タグ */}
       {user.user_tags?.length > 0 && (
         <div className="text-center my-2">
           {user.user_tags.map((tag, index) => (
@@ -92,10 +136,13 @@ export const _UsersEdit = ({ user, setUser, toggleEdit }) => {
           ))}
         </div>
       )}
+
+      {/* 自己紹介 */}
       <textarea
         className="textarea w-full rounded-md"
         rows={10}
-        defaultValue={user.profile}
+        value={profile}
+        onChange={handleProfileChange}
       />
       <div className="w-full text-center">
         <button onClick={toggleEdit} className="btn btn-primary text-xs mt-3">

--- a/frontend/src/views/users/components/_edit_service.js
+++ b/frontend/src/views/users/components/_edit_service.js
@@ -1,27 +1,49 @@
+import { useState } from "react";
+
 export const _UsersEditService = ({ serviceName, accountName }) => {
+ 
+  const [account, setAccount] = useState(accountName);
+  
+  const handleAccountChange = (e) => {
+    setAccount(e.target.value);
+  };
+
+  const getServiceLogo = (serviceName) => {
+    switch (serviceName) {
+      case "twitter":
+        return "ロゴA";
+      case "times":
+        return "ロゴB";
+      case "qiita":
+        return "ロゴC";
+      case "note":
+        return "ロゴD";
+      case "zenn":
+        return "ロゴE";
+      default:
+        return "ロゴ";
+    }
+  }
+
   return (
-    <div className="mt-1 flex rounded-md shadow-sm w-1/2 m-auto">
-      <label
-        htmlFor="mattermost"
-        className="block text-sm font-medium flex m-auto"
-      >
-        【ロゴ】
-      </label>
-      <span className="w-1/4 inline-flex h-10 items-center px-3 rounded-l-md border border-r-0 border-gray-300 bg-gray-50 text-gray-500">
-        {serviceName === "MatterMost" ? "times_" : serviceName}
-      </span>
+
+    <div className="mt-1 flex rounded-md w-5/12 m-auto">
+      <div className="w-1/4 inline-flex h-10 items-center px-3 rounded-md">
+        {getServiceLogo(serviceName)}
+      </div>
       <input
         id="userID"
         name="userID"
         placeholder={
-          serviceName === "MatterMost"
+          serviceName === "times"
             ? "times_以降を入力"
             : "アカウント名を入力"
         }
         type="text"
         required
-        defaultValue={accountName}
-        className="flex-1 form-input pl-3 block w-full rounded-none rounded-r-md transition duration-150 ease-in-out border"
+        value={account}
+        onChange={handleAccountChange}
+        className="flex-1 form-input pl-3 block w-full rounded-md transition duration-150 ease-in-out border"
       />
     </div>
   );


### PR DESCRIPTION
# 概要
ユーザプロフィールの編集画面で、useStateを使用した動的な編集を行えるようにしました。

## 挙動
動的に編集できる（編集した内容がそのまま表示される）ことを確認

https://github.com/rayto298/runtecker/assets/128275327/dfdb2160-29a4-4f48-a4b5-075cc7f05e18



## 実装内容
挙動をみてもらえればわかるかと思います

## 実装項目
[issue](https://github.com/users/rayto298/projects/4/views/1?pane=issue&itemId=56214173)でのチェック項目
ユーザプロフィール編集画面で、以下の各項目の編集をuseStateを利用して動的に行えること
- [x] ニックネーム
- [x]  都道府県
- [x]  アバター
- [x]  サービスのリンク
- [x]  自己紹介文


## 補足
なし

## 備考
レイアウトの更新や、DB連携の実装は行なっていません。
本Issueでは動的な編集を行えるようにしたのみです。