### PR TITLE
【feature】DBから取得したデータをユーザ編集画面に表示できるよう修正

### DIFF
--- a/backend/db/seeds.rb
+++ b/backend/db/seeds.rb
@@ -25,7 +25,7 @@ end
 
 # social_services のシードデータ作成
 social_services = [
-  "Qiita", "Zenn", "X", "Notion", "Mattermost"
+  "Mattermost", "GitHub", "X", "Qiita", "Zenn", "note", 
 ]
 social_services.each do |service_name|
   SocialService.find_or_create_by(name: service_name, service_type: "default")

--- a/frontend/src/views/users/components/_edit.jsx
+++ b/frontend/src/views/users/components/_edit.jsx
@@ -1,7 +1,8 @@
 import { RoutePath } from "config/route_path";
 import { Link } from "react-router-dom";
 import { _UsersEditService } from "./_edit_service";
-import { useState, useCallback } from "react";
+import { useState, useEffect, useCallback } from "react";
+import { PrefecturesController } from "controllers/prefectures_controller";
 import {
   //ここからdnd-kit
   DndContext,
@@ -19,22 +20,7 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 
-export const _UsersEdit = ({ user, originalData, setUser, toggleEdit }) => {
-  console.log(user); // ここで受け取ったuserオブジェクトを確認
-  console.log(originalData); // ここで受け取ったoriginalDataオブジェクトを確認
-  // 都道府県の仮データ
-  const prefectures = [
-    { id: 1, name: "北海道" },
-    { id: 2, name: "青森県" },
-    { id: 3, name: "岩手県" },
-    { id: 4, name: "宮城県" },
-    { id: 5, name: "長野県" },
-    { id: 6, name: "山形県" },
-    { id: 7, name: "福島県" },
-    { id: 8, name: "茨城県" },
-    { id: 9, name: "栃木県" },
-    { id: 10, name: "群馬県" },
-  ];
+export const _UsersEdit = ({ user, toggleEdit }) => {
 
   //タグの仮データ
   const tagData = [
@@ -94,10 +80,22 @@ export const _UsersEdit = ({ user, originalData, setUser, toggleEdit }) => {
   };
 
   // 都道府県
-  const [prefecture, setPrefecture] = useState(user.prefecture);
+  const [prefectures, setPrefectures] = useState([]);
+  const [prefectureId, setPrefectureId] = useState(user.prefecture.id);
   const handlePrefectureChange = (e) => {
-    setPrefecture(e.target.value);
-  };
+    setPrefectureId(e.target.value);
+  }
+
+  useEffect(() => {
+    let prefectures = new PrefecturesController();
+    prefectures.getPrefectures().then((data) => {
+      if (data) {
+        setPrefectures(data);
+      } else {
+        setPrefectures([]);
+      }
+    });
+  }, []);
 
   // アバター
   const [avatar, setAvatar] = useState(user.avatar);
@@ -147,15 +145,18 @@ export const _UsersEdit = ({ user, originalData, setUser, toggleEdit }) => {
 
         {/* 都道府県 */}
         <div className="w-1/2 flex justify-center items-center text-2xl gap-2">
-          <p>{user.term}</p>
+          <p>{user.term.name}</p>
           <select
-            className="ms-1 select text-center w-2/5 max-w-xs rounded-md text-lg"
-            value={prefecture}
-            onChange={handlePrefectureChange}
+          className="ms-1 select text-center w-2/5 max-w-xs rounded-md text-lg"
+          id="prefecture"
+          name="prefecture"
+          required
+          value={prefectureId}
+          onChange={handlePrefectureChange}
           >
-            {prefectures.map((prefecture) => (
-              <option key={prefecture.id} value={prefecture.name}>
-                {prefecture.name}
+            {prefectures.map((p) => (
+              <option value={p.id}>
+                {p.name}
               </option>
             ))}
           </select>

--- a/frontend/src/views/users/components/_edit_service.js
+++ b/frontend/src/views/users/components/_edit_service.js
@@ -9,7 +9,7 @@ import { NoteLogo } from "ui_components/icons/NoteLogo";
 export const _UsersEditService = ({ serviceName, user }) => {
  
   const getAccountName = (serviceName) => {
-    const service = user.user_social_services.find(service => service.name === serviceName);
+    const service = user.user_social_services.find(service => service.social_service.name === serviceName);
     return service ? service.account_name : "";
   };
   


### PR DESCRIPTION
# 概要
DBから取得したユーザ情報をユーザ編集画面に表示させるように修正

## 挙動
「実装内容」に記載

## 実装内容
・DBに準備したPrefecture（件数が多いので、49件入っていることを確認した結果を貼り付けています）
<img width="569" alt="image" src="https://github.com/rayto298/runtecker/assets/128275327/dcf989dd-ca01-49c5-8dfd-9d99f97b43ef">

・DBに準備したUser（prefecture_id: 13 は"東京都"です）
<img width="729" alt="image" src="https://github.com/rayto298/runtecker/assets/128275327/f9ed65cb-cc30-4f15-8193-1ef2cba4b9b4">

・DBに準備したUserSocialService（テストユーザのすべてのサービスにデータを入れています）
<img width="571" alt="image" src="https://github.com/rayto298/runtecker/assets/128275327/4850322b-54ce-4dd4-88c2-ea4c85ece84a">

・表示内容の確認（DBから取得したデータが表示されていることを確認）
![image](https://github.com/rayto298/runtecker/assets/128275327/d6e8ba6b-84e5-46a8-8816-7e11647f81de)

・表示内容の確認（デフォルトで"東京都が選択された状態になっていることを、プルダウンを開いた状態でも確認）
![image](https://github.com/rayto298/runtecker/assets/128275327/eef59b6b-a094-4062-893c-008c480ed205)


## 実装項目
「概要」に記載

## 補足
・本IssueはDBから取得したデータを表示するように修正したのみで、ユーザ更新処理は未実装です。
・アバターとタグのDB連携は未実装のため、仮データを表示している状態です。
・ついでに、SocialServiceのデータを作成するseed.rbを修正し、以下の順序で登録されるようにしました。
1. Mattermost
2. GitHub
3. X
4. Qiita
5. Zenn
6. note 


## 備考
なし