### PR TITLE
【fix】ユーザ登録画面で都道府県とタームの取得時に認証が不要なよう修正

### DIFF
--- a/backend/app/controllers/api/v1/prefectures_controller.rb
+++ b/backend/app/controllers/api/v1/prefectures_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::PrefecturesController < ApplicationController
+  skip_before_action :authenticate_request
+  
   def index
     prefectures = Prefecture.all
     render json: prefectures, status: :ok

--- a/backend/app/controllers/api/v1/terms_controller.rb
+++ b/backend/app/controllers/api/v1/terms_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::TermsController < ApplicationController
+  skip_before_action :authenticate_request
+  
   def index
     terms = Term.all
     render json: terms, status: :ok


### PR DESCRIPTION
# 概要
ユーザ登録画面で都道府県とタームの取得時に認証が必要となっており表示されない状態になっていたのを、認証が不要なよう修正しました。

## 挙動
・変更前
https://github.com/rayto298/runtecker/assets/128275327/d6b4ad53-455a-4b2f-8fb6-b4595538547e

・変更後
https://github.com/rayto298/runtecker/assets/128275327/6207e21c-6d6e-4dd3-a111-da9e04c9d08e

## 実装内容
prefectures_controller.rbと、terms_controller.rbに、「skip_before_action :authenticate_request」を記載したのみです。

## 実装項目
なし

## 補足
なし

## 備考
なし