### PR TITLE
【feature】旧ニックネームの登録処理を実装

### DIFF
--- a/backend/app/controllers/api/v1/users_controller.rb
+++ b/backend/app/controllers/api/v1/users_controller.rb
@@ -54,7 +54,11 @@ class Api::V1::UsersController < ApplicationController
   end
 
   def update_params
-    params.require(:user).permit(:nickname, :prefecture_id, :avatar, :profile, user_social_services_attributes: [:id, :social_service_id, :account_name])
+    params.require(:user).permit(
+      :nickname, :prefecture_id, :avatar, :profile, 
+      user_social_services_attributes: [:id, :social_service_id, :account_name],
+      past_nicknames_attributes: [:nickname]
+    )
   end
 
   # 検索用のパラメータを取得

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -9,7 +9,9 @@ class User < ApplicationRecord
   has_many :social_services, through: :user_social_services
   belongs_to :term
   belongs_to :prefecture
+  # ユーザ更新時にuser以外のテーブルも更新できるようにするための設定
   accepts_nested_attributes_for :user_social_services
+  accepts_nested_attributes_for :past_nicknames
 
   scope :with_nickname, ->(nickname) {
     sanitized_nickname = ActiveRecord::Base.sanitize_sql_like(nickname)

--- a/frontend/src/views/users/components/_edit.jsx
+++ b/frontend/src/views/users/components/_edit.jsx
@@ -23,12 +23,6 @@ import { CSS } from "@dnd-kit/utilities";
 import { _Avatar } from "./_avatar";
 import { useNavigate } from "react-router-dom";
 import { useParams } from "react-router-dom"
-import { SiMattermost } from "react-icons/si";
-import { RiTwitterXFill } from "react-icons/ri";
-import { FaGithub } from "react-icons/fa";
-import { QiitaLogo } from "ui_components/icons/QiitaLogo";
-import { ZennLogo } from "ui_components/icons/ZennLogo";
-import { NoteLogo } from "ui_components/icons/NoteLogo";
 import { API_URL } from "config/settings";
 
 export const _UsersEdit = ({ user, toggleEdit, isEdit, setIsEdit, handleUserUpdated }) => {
@@ -232,13 +226,23 @@ export const _UsersEdit = ({ user, toggleEdit, isEdit, setIsEdit, handleUserUpda
         }
       }
     });
-  
+
+    // PastNickname更新用の配列
+    let pastNicknameAttributes = [];
+
+    if (nickname !== initialUserState.nickname) {
+      pastNicknameAttributes.push({
+        nickname: initialUserState.nickname
+      });
+    }
+
     return {
       nickname: nickname !== initialUserState.nickname ? nickname : undefined,
       prefecture_id: Number(prefectureId) !== Number(initialUserState.prefecture_id) ? prefectureId : undefined,
       avatar: avatar !== initialUserState.avatar ? avatar : undefined,
       profile: profile !== initialUserState.profile ? profile : undefined,
       user_social_services_attributes: userSocialServicesAttributes.length > 0 ? userSocialServicesAttributes : undefined,
+      past_nicknames_attributes: pastNicknameAttributes.length > 0 ? pastNicknameAttributes : undefined,
     };
   }
 


### PR DESCRIPTION
# 概要
ニックネームを更新した際に、旧ニックネームをpast_nicknameに登録し、画面に表示する処理を実装

## 挙動
ニックネームを更新した際の挙動（直近の旧ニックネームが表示されることを確認）
https://github.com/rayto298/runtecker/assets/128275327/e45a341e-c4d6-4f21-942d-115ccfc89ae8

## 実装内容
ニックネームを変更するたび、データベースのpast_nicknameが更新されることを確認
![3c7746494d657be41966eb0106de6542](https://github.com/rayto298/runtecker/assets/128275327/6e385fe6-349e-4987-9a5d-16956414461a)

## 実装項目
特になし

## 補足
特になし

## 備考
特になし