### PR TITLE
【fix】SNSアカウント名が空で保存された時にレコードを削除

### DIFF
--- a/backend/app/controllers/api/v1/users_controller.rb
+++ b/backend/app/controllers/api/v1/users_controller.rb
@@ -33,7 +33,16 @@ class Api::V1::UsersController < ApplicationController
   # PATCH/PUT /api/v1/users/:id
   def update
     @user = User.find(params[:id])
-    if @user.update(update_params)
+
+    # 設定されていたSNSアカウント名が空になっていた場合、UserSocialServiceから該当レコードを削除する処理
+    if params[:user][:user_social_services_to_delete].present?
+      params[:user][:user_social_services_to_delete].each do |id|
+        user_social_service = @user.user_social_services.find_by(id: id)
+        user_social_service.destroy if user_social_service
+      end
+    end
+    
+    if @user.update(update_params.except(:user_social_services_to_delete))
       render json: @user
     else
       render json: @user.errors, status: :unprocessable_entity
@@ -66,8 +75,9 @@ class Api::V1::UsersController < ApplicationController
   def update_params
     params.require(:user).permit(
       :nickname, :prefecture_id, :avatar, :profile, 
+      past_nicknames_attributes: [:nickname],
       user_social_services_attributes: [:id, :social_service_id, :account_name],
-      past_nicknames_attributes: [:nickname]
+      user_social_services_to_delete: [:id]
     )
   end
 

--- a/frontend/src/views/users/components/_edit.jsx
+++ b/frontend/src/views/users/components/_edit.jsx
@@ -247,20 +247,31 @@ export const _UsersEdit = ({ user, toggleEdit, isEdit, setIsEdit, handleUserUpda
     ];
   
     let userSocialServicesAttributes = [];
+    let userSocialServicesToDelete = [];
   
     socialServicesInfo.forEach(({ serviceName, currentAccountName, initialAccountName }) => {
       const userSocialServiceId = getUserSocialServiceId(serviceName);
-      if (initialAccountName !== currentAccountName) {
-        if (userSocialServiceId) {
-          userSocialServicesAttributes.push({
-            id: userSocialServiceId,
-            account_name: currentAccountName
-          });
+      // currentAccountNameが空、またはスペースのみの場合に対応
+      const trimmedAccountName = currentAccountName.trim();
+      if (initialAccountName !== trimmedAccountName) {
+        if (trimmedAccountName === "") {
+          // アカウント名が空になっている（またはスペースのみだった）場合、削除リストに追加
+          if (userSocialServiceId) {
+            userSocialServicesToDelete.push(userSocialServiceId);
+          }
         } else {
-          userSocialServicesAttributes.push({
-            social_service_id: getSocialServiceId(serviceName),
-            account_name: currentAccountName
-          });
+          // 更新または新規追加の属性
+          if (userSocialServiceId) {
+            userSocialServicesAttributes.push({
+              id: userSocialServiceId,
+              account_name: trimmedAccountName
+            });
+          } else {
+            userSocialServicesAttributes.push({
+              social_service_id: getSocialServiceId(serviceName),
+              account_name: trimmedAccountName
+            });
+          }
         }
       }
     });
@@ -279,8 +290,9 @@ export const _UsersEdit = ({ user, toggleEdit, isEdit, setIsEdit, handleUserUpda
       prefecture_id: Number(prefectureId) !== Number(initialUserState.prefecture_id) ? prefectureId : undefined,
       avatar: avatar !== initialUserState.avatar ? avatar : undefined,
       profile: profile !== initialUserState.profile ? profile : undefined,
-      user_social_services_attributes: userSocialServicesAttributes.length > 0 ? userSocialServicesAttributes : undefined,
       past_nicknames_attributes: pastNicknameAttributes.length > 0 ? pastNicknameAttributes : undefined,
+      user_social_services_attributes: userSocialServicesAttributes.length > 0 ? userSocialServicesAttributes : undefined,
+      user_social_services_to_delete: userSocialServicesToDelete.length > 0 ? userSocialServicesToDelete : undefined,
     };
   }
 
@@ -297,6 +309,7 @@ export const _UsersEdit = ({ user, toggleEdit, isEdit, setIsEdit, handleUserUpda
       try {
         const apiUrl = process.env.REACT_APP_API_URL;
         const token = localStorage.getItem("authToken");
+        console.log(updatedFields);
 
         const response = await fetch(`${API_URL}/api/v1/users/${id}`, {
           method: "PATCH",


### PR DESCRIPTION
# 概要
SNSアカウント名が空で保存された時にUserSocialServiceの該当レコードを削除するように改修

## 挙動
・SNSアカウント名が空で保存された際に、一覧、詳細、編集画面から表示が消えることを確認
https://github.com/rayto298/runtecker/assets/128275327/0a00e9b7-1032-438c-ab77-ed6ccc723531

削除前DB
<img width="728" alt="7b63f638f8d0e224e918aca2e9c0c13b" src="https://github.com/rayto298/runtecker/assets/128275327/8e6bb18e-6e26-4904-9b76-6ed679d3088f">

削除後DB
<img width="724" alt="fded095546e65f1572904c10cd407075" src="https://github.com/rayto298/runtecker/assets/128275327/ccfd7673-50a6-4889-a45e-8253e25e3d2c">

・スペースが入力された場合はトリミングを行い、スペースのみの連続なら空データとして判定してデータを削除、アカウント名＋スペースならスペースのみ除外して登録する
https://github.com/rayto298/runtecker/assets/128275327/76aed965-885a-4462-b246-e64ce76ca1d9

・noteのアカウント名の更新も問題なく行えることを確認
https://github.com/rayto298/runtecker/assets/128275327/7cb8aacd-a856-44ab-9947-27360b404512

## 実装内容
挙動をご確認ください

## 実装項目
特になし

## 補足
特になし

## 備考
ソーシャルサービスでnoteの更新時にエラーが起きると伺ったのですが、自分のところではなぜか再現せずでした。。
本変更を行った後も特に問題はなさそうに見受けられたので、大丈夫かと思います！（たぶん）