### PR TITLE
【fix】ユーザー一覧カードのサイズ修正

### DIFF
--- a/frontend/src/views/users/components/_user.jsx
+++ b/frontend/src/views/users/components/_user.jsx
@@ -27,10 +27,17 @@ export const _User = memo((user) => {
     }
   }
 
+  // タグの最大表示数を設定
+  const maxTagsToShow = 7;
+
+  // 最大表示文字数を設定
+  const maxTagLength = 10;
+
   return (
     <div
       key={userData.id}
       className="card w-96 border border-[#CED4DA] m-4 shadow-xl overflow-hidden hover:shadow-2xl group rounded-xl p-5 transition-all duration-200 transform bg-white"
+      style={{ height: '400px' }}
     >
       <Link
         to={`${RoutePath.Users.path}?term=${userData.term.id}`}
@@ -79,16 +86,31 @@ export const _User = memo((user) => {
         <Link to={RoutePath.UsersShow.path(userData.id)}>詳細 →</Link>
       </div>
       {userData.tags?.length > 0 &&
+        // <div className="p-2 m-4 border-t border-black">
+        //   {userData.tags.map((tag, index) => (
+        //     <Link
+        //       to={`${RoutePath.Users.path}?tagId=${tag.id}`}
+        //       key={index}
+        //       className="badge badge-outline hover:opacity-50 transition-all mr-2"
+        //     >
+        //       {tag.name}
+        //     </Link>
+        //   ))}
+        // </div>
         <div className="p-2 m-4 border-t border-black">
-          {userData.tags.map((tag, index) => (
+          {userData.tags.slice(0, maxTagsToShow).map((tag, index) => ( // タグを最大数までスライスして表示
             <Link
               to={`${RoutePath.Users.path}?tagId=${tag.id}`}
               key={index}
               className="badge badge-outline hover:opacity-50 transition-all mr-2"
+              title={tag.name.length > maxTagLength ? tag.name : null} // タグが長すぎる場合にはタイトル属性を追加
             >
-              {tag.name}
+              {tag.name.length > maxTagLength ? `${tag.name.slice(0, maxTagLength)}...` : tag.name}
             </Link>
           ))}
+          {userData.tags.length > maxTagsToShow && (
+            <p className="text-gray-500 text-sm text-right mt-2">(他 {userData.tags.length - maxTagsToShow} 個タグ有)</p>
+          )}
         </div>
       }
     </div>

--- a/frontend/src/views/users/components/_user.jsx
+++ b/frontend/src/views/users/components/_user.jsx
@@ -86,24 +86,13 @@ export const _User = memo((user) => {
         <Link to={RoutePath.UsersShow.path(userData.id)}>詳細 →</Link>
       </div>
       {userData.tags?.length > 0 &&
-        // <div className="p-2 m-4 border-t border-black">
-        //   {userData.tags.map((tag, index) => (
-        //     <Link
-        //       to={`${RoutePath.Users.path}?tagId=${tag.id}`}
-        //       key={index}
-        //       className="badge badge-outline hover:opacity-50 transition-all mr-2"
-        //     >
-        //       {tag.name}
-        //     </Link>
-        //   ))}
-        // </div>
         <div className="p-2 m-4 border-t border-black">
-          {userData.tags.slice(0, maxTagsToShow).map((tag, index) => ( // タグを最大数までスライスして表示
+          {userData.tags.slice(0, maxTagsToShow).map((tag, index) => (
             <Link
               to={`${RoutePath.Users.path}?tagId=${tag.id}`}
               key={index}
               className="badge badge-outline hover:opacity-50 transition-all mr-2"
-              title={tag.name.length > maxTagLength ? tag.name : null} // タグが長すぎる場合にはタイトル属性を追加
+              title={tag.name.length > maxTagLength ? tag.name : null} // タグが長すぎる場合に省略
             >
               {tag.name.length > maxTagLength ? `${tag.name.slice(0, maxTagLength)}...` : tag.name}
             </Link>


### PR DESCRIPTION
### 概要
ユーザー一覧カードのサイズ修正


### 実装内容
[動画](https://gyazo.com/cf04a18d00b51c4d7b9c6bad955f99b6)

### 実装項目
- [x] cardの高さを固定 
- [x] card内に表示するタグの数を設定。
- [x] 残りのタグは「他◯個」という形で表示
- [x] 長いタグは「...」で省略  