### PR TITLE
【feature】60期＋pro9期まで追加

### DIFF
--- a/backend/db/seeds.rb
+++ b/backend/db/seeds.rb
@@ -1,5 +1,5 @@
 # "1期" から "60期"、"Pro-1" から "Pro-5" までのTermを作成し、"運営" を追加
-terms = (1..56).map { |i| "#{i}期" } + (1..5).map { |i| "Pro-#{i}" } + ["運営"]
+terms = (1..60).map { |i| "#{i}期" } + (1..9).map { |i| "Pro-#{i}" } + ["運営"]
 terms.each do |term_name|
   Term.find_or_create_by(name: term_name)
 end


### PR DESCRIPTION
# 概要
入学期のデータを60期までと、pro9期までを追加しました。

# 挙動
![image](https://github.com/rayto298/runtecker/assets/23026318/3bfb6f95-4ff5-4122-bbd4-dddc0def5ee7)

### 備考
運営が間に挟まってしまうのは見栄え悪いですがデータ上こうなってしまうのでどこかのタイミングで修正ししたいかなと思ってます。