### PR TITLE
【hotfix】ユーザーに紐づくリンクをURLでも対応できるよう修正

### DIFF
--- a/backend/app/models/user_social_service.rb
+++ b/backend/app/models/user_social_service.rb
@@ -3,5 +3,27 @@ class UserSocialService < ApplicationRecord
   belongs_to :social_service
 
   validates :account_name, presence: true
-  # user_idとsocial_service_idの組み合わせのユニーク性など、必要に応じてバリデーションを追加
+
+  # account_nameのセッターオーバーライド
+  def account_name=(value)
+    self[:account_name] = extract_account_name(value)
+  end
+
+  # account_nameのゲッターオーバーライド
+  def account_name
+    return self[:account_name] unless self[:account_name].start_with?("http")
+    extract_account_name(self[:account_name])
+  end
+
+  private
+
+  # URLから名前を抽出する
+  def extract_account_name(value)
+    # RUNTEQのtimes
+    if value.start_with?(ENV['RUNTEQ_MATTERMOST_URL'])
+      value.split('/').dig(-1)&.split('times_')&.dig(-1)
+    else
+      value.split('/').dig(-1)
+    end
+  end
 end

--- a/frontend/src/views/users/components/_user.jsx
+++ b/frontend/src/views/users/components/_user.jsx
@@ -17,11 +17,11 @@ export const _User = memo((user) => {
   const socialService = (name, account_name) => {
     switch (name) {
       case "Mattermost":
-        return <Link to={`https://chat.runteq.jp/runteq/channels/times_${account_name}`} className="hover:opacity-50 transition-all"><SiMattermost /></Link>;
+        return <Link to={`https://chat.runteq.jp/runteq/channels/times_${account_name}`} className="hover:opacity-50 transition-all" target="_blank"><SiMattermost /></Link>;
       case "GitHub":
-        return <Link to={`https://github.com/${account_name}`} className="hover:opacity-50 transition-all"><FaGithub /></Link>;
+        return <Link to={`https://github.com/${account_name}`} className="hover:opacity-50 transition-all" target="_blank"><FaGithub /></Link>;
       case "X":
-        return <Link to={`https://twitter.com/${account_name}`} className="hover:opacity-50 transition-all"><RiTwitterXFill /></Link>;
+        return <Link to={`https://twitter.com/${account_name}`} className="hover:opacity-50 transition-all" target="_blank"><RiTwitterXFill /></Link>;
       default:
         return null;
     }


### PR DESCRIPTION
# 概要
リンク入力でIDではなくURLを入れた場合でも動作するように修正しました。

# 挙動
gifだとカクツキがあるので動画リンクにしています。
https://i.gyazo.com/b6487f9fb1c4ddd8c92ce99994bfb67b.mp4

## 仕様
現在URLで登録しているユーザーのデータを修正するのは難しいため、account_nameを保存・取得するときにURLからIDを抽出する処理を実装しています。
account_nameのセッターゲッターをオーバーライドしている形です。

## 追加修正
一覧画面からリンクへ飛ぶと別タブにならなかったので合わせて修正しています。

## 関係issue
[#120](https://github.com/rayto298/runtecker/issues/120)